### PR TITLE
remove decoration from main window while playing

### DIFF
--- a/src/cuspid.js
+++ b/src/cuspid.js
@@ -51,6 +51,7 @@ function cuspidLoad(){
 			configureControlSocket(eventActions);
 
 			document.querySelector('body').addEventListener('keydown', event => keyHandler.handleKey(event));
+			gui.showHideDecoration(false);
 			console.log("Animation started.")
 		})
 		.catch(err => {

--- a/src/event_actions.js
+++ b/src/event_actions.js
@@ -8,6 +8,7 @@ const ZoomAnimation = require('./anim-zoomer');
 const ZoomSeqAnimation = require('./anim-zoomer-seq');
 const PaletteAnimation = require('./anim-palette');
 const ImageSequence = require('./anim-image-sequence');
+const gui = require('./gui');
 
 class EventActions {
   constructor(scene, camera, animator, textures, stats, renderer, quads){
@@ -21,7 +22,8 @@ class EventActions {
   }
 
   pause(what){
-    this.animator.pause(what);
+    const res = this.animator.pause(what);
+    gui.showHideDecoration(!res.running);
   }
 
   speedUp(amount = 5){
@@ -150,7 +152,7 @@ class EventActions {
   }
 
   modeUp(){
-    if(TwoQuadBoxScrollAnimation.prototype.isPrototypeOf(this.animator.options.animation)){
+    if(this._currentlyBoxScrolling()){
       if(this.animator.options.animation.direction === 'DOWN'){
         return this.animator.options.animation.reverse();
       }
@@ -159,7 +161,7 @@ class EventActions {
   }
 
   modeDown(){
-    if(TwoQuadBoxScrollAnimation.prototype.isPrototypeOf(this.animator.options.animation)){
+    if(this._currentlyBoxScrolling()){
       if(this.animator.options.animation.direction === 'UP'){
         return this.animator.options.animation.reverse();
       }
@@ -210,14 +212,17 @@ class EventActions {
   		animation: animation
   	});
   	this.animator.start(true);
+    gui.showHideDecoration(false);
   }
 
   _currentlyBoxScrolling(){
-    return TwoQuadBoxScrollAnimation.prototype.isPrototypeOf(this.animator.options.animation);
+    return this.animator.running &&
+      TwoQuadBoxScrollAnimation.prototype.isPrototypeOf(this.animator.options.animation);
   }
 
   _currentlyImageSequence(){
-    return ImageSequence.prototype.isPrototypeOf(this.animator.options.animation);
+    return this.animator.running &&
+      ImageSequence.prototype.isPrototypeOf(this.animator.options.animation);
   }
 }
 

--- a/src/gui.js
+++ b/src/gui.js
@@ -49,9 +49,24 @@ function wsConnectStatus(connected){
   document.querySelector('img#connstatus').src = img;
 }
 
+function showHideDecoration(show){
+  if(show){
+    console.log('hiding decorations...');
+  }
+  else{
+    console.log('showing decorations...');
+  }
+  const top = document.querySelector('#top');
+  top.style.opacity = show ? 1 : 0;
+  const cnv = document.querySelector('canvas#cnv');
+  //TODO: Don't hard code style info, instead apply/remove a class?
+  cnv.style.border = show ? 'solid white 5px' : '0px';
+}
+
 module.exports = {
   toggleKeys,
   toggleClientId,
   wsConnectStatus,
-  wsSetClientId
+  wsSetClientId,
+  showHideDecoration
 }

--- a/static/cuspid.css
+++ b/static/cuspid.css
@@ -20,6 +20,15 @@ div#top {
 	padding-top: 1px;
 	border-bottom: dashed gray 1px;
 	z-index: 9;
+	transition: visibility 0s linear 0.5s, opacity 0.5s linear;
+	font-size: 2em;
+	background-color: #cccccc88;
+}
+
+div#top > h1 {
+	-webkit-text-fill-color: white; /* Will override color (regardless of order) */
+  -webkit-text-stroke-width: 1px;
+  -webkit-text-stroke-color: black;
 }
 
 canvas#cnv {
@@ -28,6 +37,7 @@ canvas#cnv {
 	margin: 0px;
 	top: 0px;
 	border: solid white 5px;
+	transition: border-width 0.5s linear;
 }
 
 div#imagepool {

--- a/views/workspace.pug
+++ b/views/workspace.pug
@@ -5,7 +5,7 @@ html
     script(src="/static/bundle.js")
   body
     div(id='top')
-      h1|_C_U_S_P_I_D_
+      h1|🦷_C_U_S_P_I_D_🦷
     div(id='leftside')
       div(style='display: block; position: relative')
         include ./clientid.pug


### PR DESCRIPTION
This resolves #80.  

Remove the border and top heading while animating, and use a sick css transition effect to boot!
A few minor style enhancements included.