### PR TITLE
dismiss key overlays with escape

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -6,9 +6,18 @@ function toggleKeys(){
 
 function toggleClientId(closeHandler){
   if(toggle('div#clientid')){
+
+    const escapeDismisser = event => {
+      if(event.key === 'Escape') {
+        dismissOverlays();
+        if(closeHandler) closeHandler();
+        document.querySelector('input#clientUid').removeEventListener('keydown', this);
+      }
+    };
     setTimeout(() => {
       document.querySelector('input#clientUid').disabled = null;
       document.querySelector('input#clientUid').focus();
+      document.querySelector('input#clientUid').addEventListener('keydown', escapeDismisser);
     }, 10);
     if(closeHandler){
       document.querySelector('button#closeClientId')
@@ -63,10 +72,17 @@ function showHideDecoration(show){
   cnv.style.border = show ? 'solid white 5px' : '0px';
 }
 
+function dismissOverlays(){
+  document.querySelector('div#keys').style.display = 'none';
+  document.querySelector('div#clientid').style.display = 'none';
+  document.querySelector('canvas#cnv').focus();
+}
+
 module.exports = {
   toggleKeys,
   toggleClientId,
   wsConnectStatus,
   wsSetClientId,
-  showHideDecoration
+  showHideDecoration,
+  dismissOverlays
 }

--- a/src/key_handler.js
+++ b/src/key_handler.js
@@ -37,6 +37,7 @@ class KeyHandler {
             gui.toggleClientId();
             self.enabled = true;
         }),
+        'Escape': () => gui.dismissOverlays(),
         ' ': () => this.eventActions.pause(),
         '+': () => this.eventActions.speedUp(5),
         '-': () => this.eventActions.slowDown(5),


### PR DESCRIPTION
This resolves #90.

Well, it's not perfect, but in lieu of an actual GUI framework will have to do for now.  The obvious problem right now is that the handler is only attached to the cnv and text input box, so if you tab over to the close button (for instance), we lose the esc ability.  I think this is fringe, so this PR should get most of it. 