### PR TITLE
Introducing the blend mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,16 @@ Then point a browser to http://localhost:8080/workspace
 * T - tunnel/zoom sequence (out)
 * shift ⟵ - pallete scroll down
 * shift →  palette scroll up
+* b - blend mode
 
 ## misc
 * SPACE - pause
-* \+ - increase animathttps://github.com/breedx2/cuspid/raw/master/docs/cuspid_topology.pngion speed
-* \- - decrease animation speed
-* ctrl ⟵ - decrease animation delta x
-* ctrl → - increase animation delta x
-* ctrl ↑ - decrease animation delta y
-* ctrl ↓ - increase animation delta y  
+* \+ - speed up
+* \- - slow down
+* ctrl ⟵ - nudge left
+* ctrl → - nudge right
+* ctrl ↑ - nudge up
+* ctrl ↓ - nudge down
 * z - zoom out (when in scrolling mode)
 * shift z - zoom in (when in scrolling mode)
 * n - change image

--- a/src/Animator.js
+++ b/src/Animator.js
@@ -54,6 +54,7 @@ class Animator {
 			this.options.scene.remove(quad);
 			// scene.add(quad);
 			quad.material.uniforms['colorCycle'].value = 0.0;
+			quad.material.uniforms['alpha'].value = 1.0;
 			quad.material.uniforms['uvOffset'].value.set( 0, 0 );
 			quad.scale.set( 1.0, 1.0, 1.0 );
 		});

--- a/src/anim-blend.js
+++ b/src/anim-blend.js
@@ -2,7 +2,7 @@
 
 const THREE = require('three');
 
-class FadeAnimation {
+class BlendAnimation {
 
 	constructor (quads){
 		this.quads = quads;
@@ -11,17 +11,17 @@ class FadeAnimation {
 			quads[i].position.copy(new THREE.Vector3(0, 0, z));
 		}
 		this.acc = 0.0;
+		this.bias = 1.25 / this.quads.length;
 	}
 
 	tick(timeMult){
 
-		const bias = 1.05 / this.quads.length;
 		const pslice = 2 * 3.1415 / this.quads.length;
 
 		for(let i = 0; i < this.quads.length; i++){
 
 			const a = (Math.sin(this.acc + (i * pslice)) + 1.0) / 2.0;
-			_alpha(this.quads[i], bias * a);
+			_alpha(this.quads[i], this.bias * a);
 
 		}
 		this.acc += 0.05 * timeMult;
@@ -40,4 +40,4 @@ function _alpha(quad, value){
 	quad.material.uniforms.alpha.value = value;
 }
 
-module.exports = FadeAnimation;
+module.exports = BlendAnimation;

--- a/src/anim-fader.js
+++ b/src/anim-fader.js
@@ -7,32 +7,16 @@ class FadeAnimation {
 	constructor (quads, jerkiness){
 		this.quads = quads;
 		for(let i = 0; i < quads.length; i++){
-			const x = 0.01 * i;
-			// quads[i].position.copy(new THREE.Vector3(28 * x, 0, x));
-			quads[i].position.copy(new THREE.Vector3(0, 0, x));
-			// const a = (i+1) * (0.5 / quads.length );
-			// _alpha(quads[i], a);
+			const z = 0.001 * i;
+			quads[i].position.copy(new THREE.Vector3(0, 0, z));
 		}
 		this.acc = 0.0;
 		this.jerkiness = jerkiness;
-
-		/*this.quads.forEach(quad => {
-			//center
-			quad.position.copy(new THREE.Vector3(28* z, 0, z));
-			z = z + 0.01;
-			// _makeTransparent(quad);
-		});*/
-		// this.quadA = quads[1];
-		// this.quadB = quads[2];
-		//
-		// this.jerkiness = jerkiness;
-		// this.scaleA = 0;
-		// this.scaleB = .5;
 	}
 
 	tick(timeMult){
 
-		const bias = 0.5;
+		const bias = 1.05 / this.quads.length;
 		const pslice = 2 * 3.1415 / this.quads.length;
 
 		for(let i = 0; i < this.quads.length; i++){
@@ -40,98 +24,9 @@ class FadeAnimation {
 			const a = (Math.sin(this.acc + (i * pslice)) + 1.0) / 2.0;
 			_alpha(this.quads[i], bias * a);
 
-
-			// _incAlpha(this.quads[i], 0.001);
-			// const x = 0.01 * i;
-			// quads[i].position.copy(new THREE.Vector3(28 * x, 0, x));
-			// const a = (i+1) * (0.5 / quads.length );
-			// _alpha(quads[i], a);
 		}
-		this.acc += 0.01 * this.jerkiness;
-
-		// const lastQuad = this._lastQuad();
-		// if(lastQuad.material.uniforms.alpha.value > 0.5){
-		// 	this._frontToBack(lastQuad);
-		// }
-
-
-		// this.quads.forEach(quad => {
-		// 	quad.material.uniforms.alpha.value -= 0.005;
-		// });
-
-		// if(this.scaleB < 0 || this.scaleA > 0.5){
-		// 	this._frontToBack();
-		// }
-		//
-		// this.scaleA += 0.001;
-		// this.scaleB -= 0.001;
-		// console.log(`A = ${this.scaleA}, B = ${this.scaleB}`)
-		//
-		// _alpha(this.quadA, this.scaleA);
-		// _alpha(this.quadB, this.scaleB);
+		this.acc += 0.01 * this.jerkiness * timeMult;
 	}
-
-	_frontToBack(lastQuad){
-		console.log(`front to back! ${lastQuad.uuid}`);
-
-		_alpha(lastQuad, 0);
-		this.quads.unshift(this.quads.pop());
-	}
-
-	_lastQuad(){
-		return this.quads[ this.quads.length - 1 ];
-	}
-
-	_nextImage(){
-		console.log('DEBUG: bringing in next image....')
-		this.quadA.position.copy(new THREE.Vector3(-100, 0, 0.0));	//move out of the way
-		this.quadA.scale.copy(new THREE.Vector3(0, 0, 0));
-		this.quads.push(this.quads.shift());
-		this.quadA = this.quads[0];
-		this.quadB = this.quads[1];
-		this.scaleA = this.scaleB;
-		this.scaleB = 0;
-		this._toCenter(this.quadB);
-		this.quadB.scale.copy(new THREE.Vector3(0, 0, 1.0));
-	}
-
-
-	// _scaleOut(timeMult, scaleA){
-	// 	let scaleB = this._computeScale(timeMult, this.scaleB);
-	// 	this.scaleB = scaleB;
-	// 	this.quadB.scale.copy(new THREE.Vector3(scaleB, scaleB, 1.0));
-	//
-	// 	if(this.scaleA <= ENTRY_SCALE){
-	// 		this._nextImage();
-	// 	}
-	// }
-	//
-	// _scaleIn(timeMult, scaleA){
-	// 	if((scaleA > ENTRY_SCALE) && (this.scaleB < MIN_SCALE)){
-	// 		console.log("BOOP!");
-	// 		this.scaleB = MIN_SCALE;
-	// 		this._toCenter(this.quadB);
-	// 	}
-	// 	if(this.scaleB > 0){
-	// 		var scaleB = this._computeScale(timeMult, this.scaleB);
-	// 		this.scaleB = scaleB;
-	// 		this.quadB.scale.copy(new THREE.Vector3(scaleB, scaleB, 1.0));
-	// 	}
-	// 	if(scaleB > 1.0){
-	// 		console.log(`SWIZ! ${this.scaleA} ${this.scaleB}`);
-	// 		return this._nextImage();
-	// 	}
-	// }
-
-
-	// _computeScale(timeMult, scale){
-	// 	const dir = DIR_MULT[this.direction];
-	// 	const result = (this.direction === 'IN') ?
-	// 		scale * (1 + (timeMult * 0.025)) :
-	// 		scale * (1 - (timeMult * 0.025));
-	// 	return result;
-	// }
-
 }
 
 function _makeTransparent(quad){

--- a/src/anim-fader.js
+++ b/src/anim-fader.js
@@ -4,14 +4,13 @@ const THREE = require('three');
 
 class FadeAnimation {
 
-	constructor (quads, jerkiness){
+	constructor (quads){
 		this.quads = quads;
 		for(let i = 0; i < quads.length; i++){
 			const z = 0.001 * i;
 			quads[i].position.copy(new THREE.Vector3(0, 0, z));
 		}
 		this.acc = 0.0;
-		this.jerkiness = jerkiness;
 	}
 
 	tick(timeMult){
@@ -25,7 +24,7 @@ class FadeAnimation {
 			_alpha(this.quads[i], bias * a);
 
 		}
-		this.acc += 0.01 * this.jerkiness * timeMult;
+		this.acc += 0.05 * timeMult;
 	}
 }
 

--- a/src/anim-fader.js
+++ b/src/anim-fader.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const THREE = require('three');
+
+class FadeAnimation {
+
+	constructor (quads, jerkiness){
+		this.quads = quads;
+		for(let i = 0; i < quads.length; i++){
+			const x = 0.01 * i;
+			// quads[i].position.copy(new THREE.Vector3(28 * x, 0, x));
+			quads[i].position.copy(new THREE.Vector3(0, 0, x));
+			// const a = (i+1) * (0.5 / quads.length );
+			// _alpha(quads[i], a);
+		}
+		this.acc = 0.0;
+		this.jerkiness = jerkiness;
+
+		/*this.quads.forEach(quad => {
+			//center
+			quad.position.copy(new THREE.Vector3(28* z, 0, z));
+			z = z + 0.01;
+			// _makeTransparent(quad);
+		});*/
+		// this.quadA = quads[1];
+		// this.quadB = quads[2];
+		//
+		// this.jerkiness = jerkiness;
+		// this.scaleA = 0;
+		// this.scaleB = .5;
+	}
+
+	tick(timeMult){
+
+		const bias = 0.5;
+		const pslice = 2 * 3.1415 / this.quads.length;
+
+		for(let i = 0; i < this.quads.length; i++){
+
+			const a = (Math.sin(this.acc + (i * pslice)) + 1.0) / 2.0;
+			_alpha(this.quads[i], bias * a);
+
+
+			// _incAlpha(this.quads[i], 0.001);
+			// const x = 0.01 * i;
+			// quads[i].position.copy(new THREE.Vector3(28 * x, 0, x));
+			// const a = (i+1) * (0.5 / quads.length );
+			// _alpha(quads[i], a);
+		}
+		this.acc += 0.01 * this.jerkiness;
+
+		// const lastQuad = this._lastQuad();
+		// if(lastQuad.material.uniforms.alpha.value > 0.5){
+		// 	this._frontToBack(lastQuad);
+		// }
+
+
+		// this.quads.forEach(quad => {
+		// 	quad.material.uniforms.alpha.value -= 0.005;
+		// });
+
+		// if(this.scaleB < 0 || this.scaleA > 0.5){
+		// 	this._frontToBack();
+		// }
+		//
+		// this.scaleA += 0.001;
+		// this.scaleB -= 0.001;
+		// console.log(`A = ${this.scaleA}, B = ${this.scaleB}`)
+		//
+		// _alpha(this.quadA, this.scaleA);
+		// _alpha(this.quadB, this.scaleB);
+	}
+
+	_frontToBack(lastQuad){
+		console.log(`front to back! ${lastQuad.uuid}`);
+
+		_alpha(lastQuad, 0);
+		this.quads.unshift(this.quads.pop());
+	}
+
+	_lastQuad(){
+		return this.quads[ this.quads.length - 1 ];
+	}
+
+	_nextImage(){
+		console.log('DEBUG: bringing in next image....')
+		this.quadA.position.copy(new THREE.Vector3(-100, 0, 0.0));	//move out of the way
+		this.quadA.scale.copy(new THREE.Vector3(0, 0, 0));
+		this.quads.push(this.quads.shift());
+		this.quadA = this.quads[0];
+		this.quadB = this.quads[1];
+		this.scaleA = this.scaleB;
+		this.scaleB = 0;
+		this._toCenter(this.quadB);
+		this.quadB.scale.copy(new THREE.Vector3(0, 0, 1.0));
+	}
+
+
+	// _scaleOut(timeMult, scaleA){
+	// 	let scaleB = this._computeScale(timeMult, this.scaleB);
+	// 	this.scaleB = scaleB;
+	// 	this.quadB.scale.copy(new THREE.Vector3(scaleB, scaleB, 1.0));
+	//
+	// 	if(this.scaleA <= ENTRY_SCALE){
+	// 		this._nextImage();
+	// 	}
+	// }
+	//
+	// _scaleIn(timeMult, scaleA){
+	// 	if((scaleA > ENTRY_SCALE) && (this.scaleB < MIN_SCALE)){
+	// 		console.log("BOOP!");
+	// 		this.scaleB = MIN_SCALE;
+	// 		this._toCenter(this.quadB);
+	// 	}
+	// 	if(this.scaleB > 0){
+	// 		var scaleB = this._computeScale(timeMult, this.scaleB);
+	// 		this.scaleB = scaleB;
+	// 		this.quadB.scale.copy(new THREE.Vector3(scaleB, scaleB, 1.0));
+	// 	}
+	// 	if(scaleB > 1.0){
+	// 		console.log(`SWIZ! ${this.scaleA} ${this.scaleB}`);
+	// 		return this._nextImage();
+	// 	}
+	// }
+
+
+	// _computeScale(timeMult, scale){
+	// 	const dir = DIR_MULT[this.direction];
+	// 	const result = (this.direction === 'IN') ?
+	// 		scale * (1 + (timeMult * 0.025)) :
+	// 		scale * (1 - (timeMult * 0.025));
+	// 	return result;
+	// }
+
+}
+
+function _makeTransparent(quad){
+	_alpha(quad, 0.0);
+}
+
+function _incAlpha(quad, value){
+	quad.material.uniforms.alpha.value += value;
+}
+
+function _alpha(quad, value){
+	quad.material.uniforms.alpha.value = value;
+}
+
+module.exports = FadeAnimation;

--- a/src/cuspid-shader.js
+++ b/src/cuspid-shader.js
@@ -37,7 +37,6 @@ function createCuspidShaderMaterial( firstTexture ){
 		" vec2 luma = vec2( texture2D( texture, v_uv ).r, alpha);",	// sample the texture, use the red value as brightness and configurable alpha
 		" luma.r = fract( min(luma.r, 0.999) + colorCycle );",	// add color cycling, set luminance to fractional part of the result
 		" gl_FragColor = luma.xxxy;",	// Use swizzling (because it's fast). Set this texel's output RGBA color as a grayscale color with alpha .
-		// " glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);",
 		"}",
 	];
 	var fragmentShaderGLSL = fragmentShader_ar.join("\n");

--- a/src/cuspid-shader.js
+++ b/src/cuspid-shader.js
@@ -30,12 +30,14 @@ function createCuspidShaderMaterial( firstTexture ){
 
 		"uniform sampler2D texture;",	// our texture
 		"uniform float colorCycle;",	// 0..1, wraps around
+		"uniform float alpha;",
 		"varying vec2 v_uv;", // varying: This is set per-vertex in the vertex shader (above). The fragment shader interpolates the vertex values for each texel it computes.
 
 		"void main()	{",
-		" vec2 luma = vec2( texture2D( texture, v_uv ).r, 1.0 );",	// sample the texture, use the red value as brightness
+		" vec2 luma = vec2( texture2D( texture, v_uv ).r, alpha);",	// sample the texture, use the red value as brightness and configurable alpha
 		" luma.r = fract( min(luma.r, 0.999) + colorCycle );",	// add color cycling, set luminance to fractional part of the result
-		" gl_FragColor = luma.xxxy;",	// Use swizzling (because it's fast). Set this texel's output RGBA color as a grayscale color with alpha 1.0.
+		" gl_FragColor = luma.xxxy;",	// Use swizzling (because it's fast). Set this texel's output RGBA color as a grayscale color with alpha .
+		// " glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);",
 		"}",
 	];
 	var fragmentShaderGLSL = fragmentShader_ar.join("\n");
@@ -44,6 +46,8 @@ function createCuspidShaderMaterial( firstTexture ){
 		texture:    { type: 't', value: firstTexture },
 		uvOffset:   { type: 'v2', value: new THREE.Vector2( 0, 0 ) },
 		colorCycle: { type: 'f', value: 0.0 },
+		alpha: { type: 'f', value: 1.0 },
+		transparent: true, opacity: 0.3
 	};
 
 	return new THREE.RawShaderMaterial({
@@ -52,7 +56,8 @@ function createCuspidShaderMaterial( firstTexture ){
 		uniforms: uniforms,
 		depthTest: false,
 		depthWrite: false,
-		side: THREE.DoubleSide	// don't test culling
+		side: THREE.DoubleSide,	// don't test culling
+		blending: THREE.AdditiveBlending
 	});
 }
 

--- a/src/cuspid.js
+++ b/src/cuspid.js
@@ -11,7 +11,7 @@ const TwoQuadBoxScrollAnimation = require('./anim-twoquadboxscroll');
 //const ExperimentalAnimation = require('./anim-experiment')
 const ZoomSeqAnimation = require('./anim-zoomer-seq')
 const ZoomAnimation = require('./anim-zoomer')
-const FadeAnimation = require('./anim-fader')
+const BlendAnimation = require('./anim-blend')
 const ImageSequence = require('./anim-image-sequence');
 const KeyHandler = require('./key-handler');
 const EventActions = require('./event-actions');
@@ -150,7 +150,7 @@ async function startFirstAnimation(){
 		camera: camera,
 		duration: Animator.defaultAnimDuration(),
 		jerkiness: 5,
-		animation: new FadeAnimation(quads)
+		animation: new BlendAnimation(quads)
 		// animation: new ExperimentalAnimation(quads,5)
 		// animation: new ZoomAnimation(quads, 'IN', 'LINEAR')
 		// animation: new ZoomSeqAnimation(quads, 'OUT', 5)

--- a/src/cuspid.js
+++ b/src/cuspid.js
@@ -11,6 +11,7 @@ const TwoQuadBoxScrollAnimation = require('./anim-twoquadboxscroll');
 //const ExperimentalAnimation = require('./anim-experiment')
 const ZoomSeqAnimation = require('./anim-zoomer-seq')
 const ZoomAnimation = require('./anim-zoomer')
+const FadeAnimation = require('./anim-fader')
 const ImageSequence = require('./anim-image-sequence');
 const KeyHandler = require('./key-handler');
 const EventActions = require('./event-actions');
@@ -149,7 +150,7 @@ async function startFirstAnimation(){
 		camera: camera,
 		duration: Animator.defaultAnimDuration(),
 		jerkiness: 5,
-		animation: ImageSequence.build(quads)
+		animation: new FadeAnimation(quads, 5)
 		// animation: new ExperimentalAnimation(quads,5)
 		// animation: new ZoomAnimation(quads, 'IN', 'LINEAR')
 		// animation: new ZoomSeqAnimation(quads, 'OUT', 5)

--- a/src/cuspid.js
+++ b/src/cuspid.js
@@ -150,7 +150,7 @@ async function startFirstAnimation(){
 		camera: camera,
 		duration: Animator.defaultAnimDuration(),
 		jerkiness: 5,
-		animation: new FadeAnimation(quads, 5)
+		animation: new FadeAnimation(quads)
 		// animation: new ExperimentalAnimation(quads,5)
 		// animation: new ZoomAnimation(quads, 'IN', 'LINEAR')
 		// animation: new ZoomSeqAnimation(quads, 'OUT', 5)

--- a/src/event-actions.js
+++ b/src/event-actions.js
@@ -8,6 +8,7 @@ const ZoomAnimation = require('./anim-zoomer');
 const ZoomSeqAnimation = require('./anim-zoomer-seq');
 const PaletteAnimation = require('./anim-palette');
 const ImageSequence = require('./anim-image-sequence');
+const BlendAnimation = require('./anim-blend')
 const gui = require('./gui');
 
 class EventActions {
@@ -190,6 +191,10 @@ class EventActions {
 
   modeZoomSequenceOut(){
     return this._changeAnimation(ZoomSeqAnimation.zoomOut(this.quads, this.animator.options.jerkiness));
+  }
+
+  modeBlend(){
+    return this._changeAnimation(new BlendAnimation(this.quads));
   }
 
   modeImageSequence(){

--- a/src/key-handler.js
+++ b/src/key-handler.js
@@ -53,6 +53,7 @@ class KeyHandler {
         's': () => this.eventActions.modeImageSequence(),
         't': () => this.eventActions.modeZoomSequenceIn(),
         'T': () => this.eventActions.modeZoomSequenceOut(),
+        'b': () => this.eventActions.modeBlend(),
         'g': () => this.eventActions.toggleGlitchPass(),
         'F': () => this.eventActions.advanceOneFrame(),
         'Enter': () => this.eventActions.repaint(),

--- a/views/keys.pug
+++ b/views/keys.pug
@@ -46,22 +46,22 @@ div#keys(class='leftarea')
       td|pause
     tr
       td.key|+
-      td|increase animation speed
+      td|speed up
     tr
       td.key|-
-      td|decrease animation speed
+      td|slow down
     tr
       td.key|ctrl ⟵
-      td|decrease animation delta x pos
+      td|nudge left
     tr
       td.key|ctrl →
-      td|increase animation delta x pos
+      td|nudge right
     tr
       td.key|ctrl ↑
-      td|decrease animation delta y pos
+      td|nudge up
     tr
       td.key|ctrl ↓
-      td|increase animation delta y pos
+      td|nudge down
     tr
       td.key|z
       td|zoom out (when in scrolling mode)

--- a/views/keys.pug
+++ b/views/keys.pug
@@ -35,6 +35,9 @@ div#keys(class='leftarea')
     tr
       td.key|shift →
       td|palette scroll up
+    tr
+      td.key|b
+      td|blend mode
 
   h2|misc
   table


### PR DESCRIPTION
This introduces a "blend" mode bound to the 'b' key.  This mode cycles through all images and adjusts the transparency of each in turn for a blended transparency/overlay mode that satisfies #15 .  Wow, over 4 years in the making!

The mode now exists and can be leveraged with the key binding.  Some shortcomings and things that remain (will create follow-up issues for these):
* Allow bias for this mode to be manually adjusted
* Allow zooming and nudge in this mode
* Add bindings for websocket/osc
* Add to Pd patch