### PR TITLE
add ability to adjust bias for blend mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ In these examples `{id}` is the client id being addressed.
 | /{id}/nudgeRight          | {num}        | when zoomed, nudge image right by {num} amount.  only valid in some display modes.
 | /{id}/nudgeUp             | {num}        | when zoomed, nudge image up by {num} amount.  only valid in some display modes.
 | /{id}/nudgeDown           | {num}        | when zoomed, nudge image down by {num} amount.  only valid in some display modes.
+| /{id}/bias                | {num}        | when in blend mode, set the bias level to {num}
+| /{id}/biasDelta           | {delta}      | when in blend mode, adjust the bias level by {delta}
 | /{id}/advanceOneFrame     |              | advances one fake "frame". makes the most sense when paused.
 
 # Pd

--- a/pd/controller.pd
+++ b/pd/controller.pd
@@ -67,7 +67,7 @@
 #X connect 26 1 21 0;
 #X restore 84 306 pd addr;
 #X msg 130 263 symbol tony99;
-#N canvas 914 380 337 283 OSC 1;
+#N canvas 914 454 337 283 OSC 1;
 #X msg 103 192 disconnect;
 #X obj 79 218 netsend -u -b;
 #X obj 79 84 list prepend send;
@@ -179,7 +179,7 @@
 -1 -1;
 #X msg 213 204 speed \$1;
 #X obj 69 76 hsl 120 20 0 1000 0 0 empty empty speed -2 29 0 10 -261947
--1 -1 600 1;
+-1 -1 0 1;
 #X msg 98 204 pause 1;
 #X msg 155 206 pause 0;
 #X obj 194 76 bng 20 250 50 0 empty empty (+) -3 30 0 10 -162746 -1
@@ -226,7 +226,7 @@
 #X obj 57 42 bng 25 250 50 0 empty empty U 10 12 0 10 -216235 -1 -45076
 ;
 #X obj 117 72 hsl 100 15 1 33 1 0 empty empty zoom -2 -8 0 10 -262144
--1 -1 0 1;
+-1 -1 11700 1;
 #X text 216 193 zoom;
 #X msg 194 212 zoom \$1;
 #X floatatom 253 201 5 0 0 0 - - -;
@@ -339,6 +339,30 @@
 #X restore 218 114 pd effects;
 #X msg 11 258 toggleFps;
 #X msg 144 287 symbol client6;
+#N canvas 1788 435 918 625 misc 0;
+#X obj 47 46 hsl 128 15 0 1 0 0 empty empty bias 45 -8 0 9 -179445
+-1 -1 11000 1;
+#X obj 27 46 bng 15 250 50 0 empty empty (-) -3 22 0 8 -228856 -1 -1
+;
+#X obj 179 46 bng 15 250 50 0 empty empty (+) -3 22 0 8 -228856 -1
+-1;
+#X text 46 59 (only for blend mode);
+#X obj 88 234 s cmd;
+#X msg 58 135 bias \$1;
+#X floatatom 63 114 5 0 0 0 - - -;
+#X msg 104 202 biasDelta \$1;
+#X msg 16 164 -0.01;
+#X msg 114 166 0.01;
+#X connect 0 0 6 0;
+#X connect 1 0 8 0;
+#X connect 2 0 9 0;
+#X connect 5 0 4 0;
+#X connect 6 0 5 0;
+#X connect 7 0 4 0;
+#X connect 8 0 7 0;
+#X connect 9 0 7 0;
+#X coords 0 -1 1 1 180 90 1 20 20;
+#X restore 339 218 pd misc;
 #X connect 1 0 3 0;
 #X connect 2 0 1 1;
 #X connect 4 0 1 0;

--- a/src/Animator.js
+++ b/src/Animator.js
@@ -166,6 +166,22 @@ class Animator {
 		console.log('This animation does not support zooming');
 	}
 
+	biasDelta(amount){
+		if(this.options.animation.bias){
+			console.log(`Adjusting bias by ${amount}`);
+			return this.options.animation.deltaBias(amount);
+		}
+		console.log('This animation mode does not support bias');
+	}
+
+	bias(amount){
+		if(this.options.animation.bias){
+			console.log(`Setting bias to ${amount}`);
+			return this.options.animation.setBias(amount);
+		}
+		console.log('This animation mode does not support bias');
+	}
+
 	deltaY(amount){
 		if(this.options.animation.deltaY){
 			console.log('Adjusting delta Y by ' + amount);

--- a/src/anim-blend.js
+++ b/src/anim-blend.js
@@ -25,6 +25,14 @@ class BlendAnimation {
 		this.acc += 0.05 * timeMult;
 	}
 
+	deltaBias(amount){
+		this.bias += amount;
+	}
+
+	setBias(amount){
+		this.bias = amount;
+	}
+
 	_setup(){
 		this.once = true;
 		for(let i = 0; i < this.quads.length; i++){

--- a/src/event-actions.js
+++ b/src/event-actions.js
@@ -66,6 +66,15 @@ class EventActions {
     this.animator.zoom(zoomLevel);
   }
 
+  biasDelta(amount){
+    console.log(`Bias delta: ${amount}`);
+    this.animator.biasDelta(amount);
+  }
+
+  bias(amount){
+    this.animator.bias(amount);
+  }
+
   nudgeLeft(amount = 0.1){
     this.animator.deltaX(-1 * amount);
   }

--- a/src/key-handler.js
+++ b/src/key-handler.js
@@ -56,6 +56,8 @@ class KeyHandler {
         'b': () => this.eventActions.modeBlend(),
         'g': () => this.eventActions.toggleGlitchPass(),
         'F': () => this.eventActions.advanceOneFrame(),
+        '[': () => this.eventActions.biasDelta(-0.01),
+        ']': () => this.eventActions.biasDelta(0.01),
         'Enter': () => this.eventActions.repaint(),
         'ArrowLeft': this._leftArrow.bind(this),
         'ArrowRight': this._rightArrow.bind(this),

--- a/src/ws-events.js
+++ b/src/ws-events.js
@@ -116,6 +116,10 @@ function handleControlEvent(oscEvent, eventActions, id){
     return eventActions.nudgeUp(oscEvent.args[0]);
   case `/${id}/nudgeDown`:
     return eventActions.nudgeDown(oscEvent.args[0]);
+  case `/${id}/bias`:
+    return eventActions.bias(oscEvent.args[0]);
+  case `/${id}/biasDelta`:
+    return eventActions.biasDelta(oscEvent.args[0]);
   case `/${id}/advanceOneFrame`:
     return eventActions.advanceOneFrame();
  }

--- a/views/keys.pug
+++ b/views/keys.pug
@@ -45,11 +45,8 @@ div#keys(class='leftarea')
       td.key|SPACE
       td|pause
     tr
-      td.key|+
-      td|speed up
-    tr
-      td.key|-
-      td|slow down
+      td.key|+ -
+      td|speed up / down
     tr
       td.key|ctrl ⟵
       td|nudge left
@@ -68,6 +65,9 @@ div#keys(class='leftarea')
     tr
       td.key|shift z
       td|zoom in (when in scrolling mode)
+    tr
+      td.key|[ ]
+      td|blend bias up/down
     tr
       td.key|n
       td|next image


### PR DESCRIPTION
Fixes #113. Bias is now adjustable with `[` and `]` and OSC messages.